### PR TITLE
no default value for $OPTS{user}

### DIFF
--- a/mysql-genocide
+++ b/mysql-genocide
@@ -266,7 +266,7 @@ our %OPTS =
     'host|h=s'        => undef,
     'port|P=i'        => undef,
     'database|D=s'    => undef,
-    'user|u=s'        => $ENV{'USER'},
+    'user|u=s'        => undef,
     'password|p=s'    => undef,
 
     'filter|f'        => undef,
@@ -368,7 +368,7 @@ $dsn .= 'database=' . $OPTS{'database'} . ';' if($OPTS{'database'});
 $dsn .= 'host='     . $OPTS{'host'}     . ';' if($OPTS{'host'});
 $dsn .= 'port='     . $OPTS{'port'}     . ';' if($OPTS{'port'});
 
-if(defined($ENV{'HOME'}))
+if(defined($ENV{'HOME'}) and -e $ENV{'HOME'} . '/.my.cnf')
 {
     $dsn .= 'mysql_read_default_file=' . $ENV{'HOME'} . '/.my.cnf';
 }


### PR DESCRIPTION
It is unneeded to define a default value for $OPTS{user} as $ENV{USER}, because DBI do the substitution on its own when `user` parameter is NULL and also it overrides `user` option defined in .my.cnf ! If you have a proper .my.cnf and you do not give --user parameter in command line, you probably want to get `user` parameter from config file.
